### PR TITLE
Added an exception when "site_id" is not passed into ValoreBooksPriceClient

### DIFF
--- a/src/Clients/ValoreBooksPriceClient.php
+++ b/src/Clients/ValoreBooksPriceClient.php
@@ -8,6 +8,11 @@ class ValoreBooksPriceClient extends PriceClient
 
     public function __construct($config = [])
     {
+        if (!isset($config['site_id'])) {
+            throw new \InvalidArgumentException(
+                'A "site_id" key must be included in the $config array argument'
+            );
+        }
         parent::__construct();
         $this->baseUrl = 'http://prices.valorebooks.com/lookup-multiple-categories';
         $this->query['SiteID'] = $config['site_id'];

--- a/test/Clients/ValoreBooksPriceClientTest.php
+++ b/test/Clients/ValoreBooksPriceClientTest.php
@@ -28,9 +28,9 @@ class ValoreBooksPriceClientTest extends \PHPUnit_Framework_TestCase
 
         $this->client->processSalePrices($response);
         foreach ($this->client->collection as $key => $book) {
-            $this->assertEquals($response['product-code'], $book->isbn13 );
-            $this->assertEquals($response['sale-offer']['price'], $book->price );
-            $this->assertEquals('valorebooks', $book->retailer );
+            $this->assertEquals($response['product-code'], $book->isbn13);
+            $this->assertEquals($response['sale-offer']['price'], $book->price);
+            $this->assertEquals('valorebooks', $book->retailer);
         }
     }
 
@@ -44,15 +44,15 @@ class ValoreBooksPriceClientTest extends \PHPUnit_Framework_TestCase
 
         $this->client->processRentalPrices($response);
         foreach ($this->client->collection as $key => $book) {
-            $this->assertEquals($response['product-code'], $book->isbn13 );
+            $this->assertEquals($response['product-code'], $book->isbn13);
             if ($book->{'price'} === $response['rental-offer']['ninty-day-price']) {
-                $this->assertEquals($response['rental-offer']['ninty-day-price'], $book->{'price'} );
+                $this->assertEquals($response['rental-offer']['ninty-day-price'], $book->{'price'});
             } elseif ($book->{'price'} === $response['rental-offer']['semester-price']) {
-                $this->assertEquals($response['rental-offer']['semester-price'], $book->{'price'} );
+                $this->assertEquals($response['rental-offer']['semester-price'], $book->{'price'});
             } else {
-                $this->assertEquals($response['sale-offer']['price'], $book->price );
+                $this->assertEquals($response['sale-offer']['price'], $book->price);
             }
-            $this->assertEquals('valorebooks', $book->retailer );
+            $this->assertEquals('valorebooks', $book->retailer);
         }
     }
 
@@ -67,15 +67,15 @@ class ValoreBooksPriceClientTest extends \PHPUnit_Framework_TestCase
 
         $this->client->addPricesToCollection($response);
         foreach ($this->client->collection as $key => $book) {
-            $this->assertEquals($response['product-code'], $book->isbn13 );
+            $this->assertEquals($response['product-code'], $book->isbn13);
             if ($book->{'price'} === $response['rental-offer']['ninty-day-price']) {
-                $this->assertEquals($response['rental-offer']['ninty-day-price'], $book->{'price'} );
+                $this->assertEquals($response['rental-offer']['ninty-day-price'], $book->{'price'});
             } elseif ($book->{'price'} === $response['rental-offer']['semester-price']) {
-                $this->assertEquals($response['rental-offer']['semester-price'], $book->{'price'} );
+                $this->assertEquals($response['rental-offer']['semester-price'], $book->{'price'});
             } else {
-                $this->assertEquals($response['sale-offer']['price'], $book->price );
+                $this->assertEquals($response['sale-offer']['price'], $book->price);
             }
-            $this->assertEquals('valorebooks', $book->retailer );
+            $this->assertEquals('valorebooks', $book->retailer);
         }
     }
 
@@ -91,15 +91,15 @@ class ValoreBooksPriceClientTest extends \PHPUnit_Framework_TestCase
 
         $this->client->addPricesToCollection($response);
         foreach ($this->client->collection as $key => $book) {
-            $this->assertEquals($response['product-code'], $book->isbn13 );
+            $this->assertEquals($response['product-code'], $book->isbn13);
             if ($book->{'price'} === $response['rental-offer']['ninty-day-price']) {
-                $this->assertEquals($response['rental-offer']['ninty-day-price'], $book->{'price'} );
+                $this->assertEquals($response['rental-offer']['ninty-day-price'], $book->{'price'});
             } elseif ($book->{'price'} === $response['rental-offer']['semester-price']) {
-                $this->assertEquals($response['rental-offer']['semester-price'], $book->{'price'} );
+                $this->assertEquals($response['rental-offer']['semester-price'], $book->{'price'});
             } else {
-                $this->assertEquals($response['sale-offer']['price'], $book->price );
+                $this->assertEquals($response['sale-offer']['price'], $book->price);
             }
-            $this->assertEquals('valorebooks', $book->retailer );
+            $this->assertEquals('valorebooks', $book->retailer);
         }
     }
 
@@ -110,9 +110,9 @@ class ValoreBooksPriceClientTest extends \PHPUnit_Framework_TestCase
 
         $results = $this->client->addPricesToCollection($response);
         foreach ($this->client->collection as $key => $book) {
-            $this->assertEquals($response['product-code'], $book->isbn13 );
-            $this->assertEquals($response['sale-offer']['price'], $book->price );
-            $this->assertEquals('valorebooks', $book->retailer );
+            $this->assertEquals($response['product-code'], $book->isbn13);
+            $this->assertEquals($response['sale-offer']['price'], $book->price);
+            $this->assertEquals('valorebooks', $book->retailer);
         }
     }
 

--- a/test/Clients/ValoreBooksPriceClientTest.php
+++ b/test/Clients/ValoreBooksPriceClientTest.php
@@ -12,6 +12,12 @@ class ValoreBooksPriceClientTest extends \PHPUnit_Framework_TestCase
         $this->client->client = m::mock('GuzzleHttp\Client');
     }
 
+    public function testExceptionIsThrownOnMissingSiteId()
+    {
+        $this->setExpectedException('InvalidArgumentException');
+        $this->client = new ValoreBooksPriceClient();
+    }
+
     public function testItAddsSalePriceToCollection()
     {
         $response = $this->generateResponse([


### PR DESCRIPTION
When a `site_id` key and value are not passed into `ValoreBooksPriceClient`'s constructor, it fails silently (well, PHP gives an "index not found" warning, but that's not very helpful). I added an exception for such a case, so this error can be caught.

Also, I cleaned up some odd formatting in the test.
